### PR TITLE
전체적인 코드 리팩터링

### DIFF
--- a/src/main/java/command/AuthCommand.java
+++ b/src/main/java/command/AuthCommand.java
@@ -15,7 +15,8 @@ public class AuthCommand extends Command {
   private static final AuthServiceImpl authService = new AuthServiceImpl();
 
   public static void run() {
-    executeCommand("사용자 인증", AuthMenu.values());
+    printTitle("사용자 인증");
+    executeCommand(AuthMenu.values());
     initialize();
   }
 

--- a/src/main/java/command/Command.java
+++ b/src/main/java/command/Command.java
@@ -105,7 +105,7 @@ public class Command {
     return title;
   }
 
-  public static String[][] getData(List<?> list) {
+  private static String[][] getData(List<?> list) {
     Field[] fields = list.get(0).getClass().getDeclaredFields();
     String[][] data = new String[list.size()][fields.length];
 
@@ -129,7 +129,7 @@ public class Command {
     return data;
   }
 
-  public static String[][] getData(List<?> list, String... args) {
+  private static String[][] getData(List<?> list, String... args) {
     String[][] data = new String[list.size()][args.length];
 
     AtomicInteger rowId = new AtomicInteger();

--- a/src/main/java/command/Command.java
+++ b/src/main/java/command/Command.java
@@ -22,8 +22,8 @@ public class Command {
     System.out.println("\n[" + title + "]");
   }
 
-  public static void executeCommand(String title, Menu[] menus) {
-    int selectedMenu = selectCommand(title, menus);
+  public static void executeCommand(Menu[] menus) {
+    int selectedMenu = selectCommand(menus);
 
     if (selectedMenu == menus.length) {
       AuthCommand.initialize();
@@ -35,8 +35,7 @@ public class Command {
     });
   }
 
-  public static int selectCommand(String title, Menu[] menus) {
-    printTitle(title);
+  public static int selectCommand(Menu[] menus) {
     printMenu(menus);
     printExitMenu(menus);
 

--- a/src/main/java/command/InsuranceDesignCommand.java
+++ b/src/main/java/command/InsuranceDesignCommand.java
@@ -14,7 +14,8 @@ public class InsuranceDesignCommand extends Command {
   private static final InsuranceDesignServiceImpl insuranceImpl = new InsuranceDesignServiceImpl();
 
   public static void run() {
-    executeCommand("보험개발", InsuranceDesignMenu.values());
+    printTitle("보험 개발");
+    executeCommand(InsuranceDesignMenu.values());
   }
 
   public static void searchInsurance() {

--- a/src/main/java/command/InsuranceDesignCommand.java
+++ b/src/main/java/command/InsuranceDesignCommand.java
@@ -11,7 +11,7 @@ import service.impl.InsuranceDesignServiceImpl;
 public class InsuranceDesignCommand extends Command {
 
   private static final InsuranceParser insuranceParser = InsuranceParser.getInstance();
-  private static final InsuranceDesignServiceImpl insuranceImpl = new InsuranceDesignServiceImpl();
+  private static final InsuranceDesignServiceImpl insuranceDesignService = new InsuranceDesignServiceImpl();
 
   public static void run() {
     printTitle("보험 개발");
@@ -20,7 +20,7 @@ public class InsuranceDesignCommand extends Command {
 
   public static void searchInsurance() {
     printTitle("보험조회");
-    List<Insurance> insuranceList = insuranceImpl.searchInsurance();
+    List<Insurance> insuranceList = insuranceDesignService.searchInsurance();
     printTable(insuranceList);
     AuthCommand.initialize();
   }
@@ -28,20 +28,15 @@ public class InsuranceDesignCommand extends Command {
   public static void designInsurance() {
     printTitle("보험설계");
     InsuranceType insuranceType = insuranceParser.getInsuranceType();
-    int count = insuranceImpl.getCountByInsuranceType(insuranceType);
+    int count = insuranceDesignService.getCountByInsuranceType(insuranceType);
 
-    Insurance insurance = Insurance.builder()
-        .insuranceType(insuranceType)
-        .insuranceCode(insuranceType.name() + "-" + (count + 1))
-        .name(insuranceParser.getName())
+    Insurance insurance = Insurance.builder().insuranceType(insuranceType)
+        .insuranceCode(insuranceType.name() + "-" + (count + 1)).name(insuranceParser.getName())
         .coverDescription(insuranceParser.getCoverDescription())
-        .interestRate(insuranceParser.getInterestRate())
-        .entryAge(insuranceParser.getEntryAge())
-        .premium(insuranceParser.getPremium())
-        .premiumRate(insuranceParser.getPremiumRate())
-        .authorizeType(AuthorizeType.AUTHORIZE_WAITED)
-        .build();
-    insuranceImpl.designInsurance(insurance);
+        .interestRate(insuranceParser.getInterestRate()).entryAge(insuranceParser.getEntryAge())
+        .premium(insuranceParser.getPremium()).premiumRate(insuranceParser.getPremiumRate())
+        .authorizeType(AuthorizeType.AUTHORIZE_WAITED).build();
+    insuranceDesignService.designInsurance(insurance);
     System.out.println("보험설계가 완료되었습니다.");
     AuthCommand.initialize();
   }
@@ -49,12 +44,12 @@ public class InsuranceDesignCommand extends Command {
   public static void requestInsurance() {
     printTitle("보험인가 요청");
     System.out.print("보험리스트 : ");
-    List<Insurance> insuranceList = insuranceImpl.searchInsurance();
+    List<Insurance> insuranceList = insuranceDesignService.searchInsurance();
     printTable(insuranceList);
     System.out.println("인가 요청할 보험을 선택해주세요");
     int selectedMenu = input();
     Insurance insurance = insuranceList.get(selectedMenu);
-    insuranceImpl.requestInsuranceApproval(insurance);
+    insuranceDesignService.requestInsuranceApproval(insurance);
     System.out.println("선택한 상품에 대한 인가 요청이 완료되었습니다.");
     AuthCommand.initialize();
   }

--- a/src/main/java/command/SalesCommand.java
+++ b/src/main/java/command/SalesCommand.java
@@ -20,11 +20,13 @@ public class SalesCommand extends Command {
   private static final SalesServiceImpl salesService = new SalesServiceImpl();
 
   public static void run() {
-    executeCommand("영업", Sales.values());
+    printTitle("영업");
+    executeCommand(Sales.values());
   }
 
   public static void manageSales() {
-    executeCommand("영업 관리", SalesManagement.values());
+    printTitle("영업 관리");
+    executeCommand(SalesManagement.values());
   }
 
   public static void manageInsurance() {
@@ -43,7 +45,8 @@ public class SalesCommand extends Command {
   }
 
   public static void manageCustomer() {
-    executeCommand("고객 관리", CustomerManagement.values());
+    printTitle("고객 관리");
+    executeCommand(CustomerManagement.values());
   }
 
   public static void searchCustomer() {
@@ -90,7 +93,8 @@ public class SalesCommand extends Command {
   }
 
   public static void manageContract() {
-    executeCommand("계약 관리", ContractManagement.values());
+    printTitle("계약 관리");
+    executeCommand(ContractManagement.values());
   }
 
   public static void searchAllContract() {
@@ -125,7 +129,8 @@ public class SalesCommand extends Command {
 
   public static void proceedContract(Contract contract) {
 
-    int selectedMenu = selectCommand("계약 진행", ContractProgress.values());
+    printTitle("계약 진행");
+    int selectedMenu = selectCommand(ContractProgress.values());
     Arrays.stream(ContractProgress.values()).forEach(menu -> {
       if (selectedMenu == menu.ordinal()) {
         menu.execute(contract);

--- a/src/main/java/command/SalesCommand.java
+++ b/src/main/java/command/SalesCommand.java
@@ -1,7 +1,7 @@
 package command;
 
-import command.menu.sales.ContractProgress;
 import command.menu.sales.ContractManagement;
+import command.menu.sales.ContractProgress;
 import command.menu.sales.CustomerManagement;
 import command.menu.sales.Sales;
 import command.menu.sales.SalesManagement;

--- a/src/main/java/command/UnderwritingCommand.java
+++ b/src/main/java/command/UnderwritingCommand.java
@@ -19,7 +19,8 @@ public class UnderwritingCommand extends Command {
 
 
   public static void run() {
-    executeCommand("인수심사", UnderwritingMenu.values());
+    printTitle("인수 심사");
+    executeCommand(UnderwritingMenu.values());
   }
 
 
@@ -103,7 +104,8 @@ public class UnderwritingCommand extends Command {
     underwritingImpl.updateInsuranceApproval(insurance, result);
 
     System.out.println("선택된 보험을 다른 방식으로 처리하시겠습니까?");
-    executeCommand("공동인수 , 재보험", UWManagement.values());
+    printTitle("공동인수 , 재보험");
+    executeCommand(UWManagement.values());
   }
 
   public static void manageCollaboration() {

--- a/src/main/java/command/UnderwritingCommand.java
+++ b/src/main/java/command/UnderwritingCommand.java
@@ -14,7 +14,7 @@ import service.impl.UnderwritingServiceImpl;
 public class UnderwritingCommand extends Command {
 
   private static final UnderwritingParser underwritingParser = UnderwritingParser.getInstance();
-  private static final UnderwritingServiceImpl underwritingImpl = new UnderwritingServiceImpl();
+  private static final UnderwritingServiceImpl underwritingService = new UnderwritingServiceImpl();
   private static final Employee employee = new Employee();
 
 
@@ -27,7 +27,7 @@ public class UnderwritingCommand extends Command {
   public static void searchAcceptancePolicy() {
     printTitle("인수정책 조회");
     String[] args = {"name", "description", "writer", "date"};
-    List<Underwriting> underwritingList = underwritingImpl.searchAcceptancePolicy();
+    List<Underwriting> underwritingList = underwritingService.searchAcceptancePolicy();
     printTable(underwritingList, args);
     AuthCommand.initialize();
   }
@@ -35,17 +35,15 @@ public class UnderwritingCommand extends Command {
   public static void createAcceptancePolicy() {
     printTitle("인수정책 수립");
     System.out.println("인수정책을 수립해주세요");
-    Underwriting input = Underwriting.builder()
-        .name(underwritingParser.getName())
+    Underwriting input = Underwriting.builder().name(underwritingParser.getName())
         .description(underwritingParser.getDescription())
-        .writer(underwritingImpl.getEmployeeName(employee))
-        .build();
-    underwritingImpl.createAcceptancePolicy(input);
+        .writer(underwritingService.getEmployeeName(employee)).build();
+    underwritingService.createAcceptancePolicy(input);
     System.out.println("인수정책 수립이 완료되었습니다");
 
     System.out.println("현재 수립된 인수정책 리스트");
     String[] args = {"name", "description", "writer", "date"};
-    List<Underwriting> underwritingList = underwritingImpl.searchAcceptancePolicy();
+    List<Underwriting> underwritingList = underwritingService.searchAcceptancePolicy();
     printTable(underwritingList, args);
     AuthCommand.initialize();
   }
@@ -53,7 +51,7 @@ public class UnderwritingCommand extends Command {
   public static void manageLossRate() {
     printTitle("손해율 관리");
     System.out.println("현재 등록된 보험 리스트");
-    List<Insurance> insuranceList = underwritingImpl.manageLossRate();
+    List<Insurance> insuranceList = underwritingService.manageLossRate();
     printTable(insuranceList);
 
     InsuranceType insuranceType = underwritingParser.getInsuranceType();
@@ -72,16 +70,16 @@ public class UnderwritingCommand extends Command {
   public static void underwrite() {
     printTitle("인수심사");
     System.out.println("인수심사 대기 리스트");
-    List<Insurance> insuranceList = underwritingImpl.getInsuranceList();
+    List<Insurance> insuranceList = underwritingService.getInsuranceList();
     List<Insurance> filteredList = insuranceList.stream()
-        .filter(i -> i.getAuthorizeType().toString().equals("인가요청"))
-        .collect(Collectors.toList());
+        .filter(i -> i.getAuthorizeType().toString().equals("인가요청")).collect(Collectors.toList());
     printTable(filteredList);
 
     System.out.println("인수심사할 보험을 선택해주세요");
     int selectedMenu = input();
     Insurance insurance = filteredList.get(selectedMenu);
-    System.out.println("인수심사 대기 고객의 이름,보험정보, 보험료는 다음과 같습니다.");
+
+    System.out.println("인수심사 대기 고객의 이름, 보험정보, 보험료는 다음과 같습니다.");
     String name = filteredList.get(selectedMenu).getName();
     String coverDescription = filteredList.get(selectedMenu).getCoverDescription();
     int premium = filteredList.get(selectedMenu).getPremium();
@@ -92,16 +90,15 @@ public class UnderwritingCommand extends Command {
         .physicalFactorScore(underwritingParser.getPhysicalFactorScore())
         .financialFactorScore(underwritingParser.getFinancialFactorScore())
         .environmentalFactorScore(underwritingParser.getEnvironmentFactorScore())
-        .moralFactorScore(underwritingParser.getMoralFactorScore())
-        .build();
-    boolean result = underwritingImpl.underwrite(underwriting);
+        .moralFactorScore(underwritingParser.getMoralFactorScore()).build();
+    boolean result = underwritingService.underwrite(underwriting);
 
     if (result) {
       System.out.println("선택된 보험에 인수가 승인되었습니다.");
     } else {
       System.out.println("선택된 보험에 인수가 거절되었습니다");
     }
-    underwritingImpl.updateInsuranceApproval(insurance, result);
+    underwritingService.updateInsuranceApproval(insurance, result);
 
     System.out.println("선택된 보험을 다른 방식으로 처리하시겠습니까?");
     printTitle("공동인수 , 재보험");


### PR DESCRIPTION
- 커맨드 메서드 책임 분리
  - `executeCommand`, `selectCommand` 메서드에서 타이틀 출력하는 로직 제거
- 커맨드 메서드 `getData` 메서드 private 지정
  - 해당 메서드는 테이블 출력에만 사용되는 메서드이므로 외부에 노출될 필요 없음
- 코드 스타일 정리